### PR TITLE
Clone tooltip

### DIFF
--- a/src/leaflet.browser.print.utils.js
+++ b/src/leaflet.browser.print.utils.js
@@ -92,7 +92,11 @@ L.browserPrintUtils = {
 
 		if (layer instanceof L.LayerGroup) {
 		   return L.layerGroup();
-	   }
+		}
+		
+		if (layer instanceof L.Tooltip) {
+            return L.tooltip();
+        }
 
 		console.info('Unknown layer, cannot clone this layer. Leaflet-version: ' + L.version);
 		

--- a/src/leaflet.browser.print.utils.js
+++ b/src/leaflet.browser.print.utils.js
@@ -120,6 +120,7 @@ L.browserPrintUtils = {
 	   if (layer instanceof L.GeoJSON) { return "L.GeoJSON"; }
 	   if (layer instanceof L.FeatureGroup) { return "L.FeatureGroup"; }
 	   if (layer instanceof L.LayerGroup) { return "L.LayerGroup"; }
+	   if (layer instanceof L.Tooltip) { return "L.Tooltip"; }
 	   return null;
    },
 


### PR DESCRIPTION
Added L.Tooltip detection to the utils cloning functions. Prevents "Unknown layer, cannot clone this layer. Leaflet-version: 1.2.0" error messages when printing maps with permanent tooltips. (Permanent tooltips are useful as labels).