### PR TITLE
this PR fixe issue 15

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Check out the:
 **Step 2.** Add the following line of code to your map script
 
 ``` js
-	L.browserPrint().addTo(map)
+	L.control.browserPrint().addTo(map)
 ```
 
 **Step 3.**

--- a/examples/localization_v1.2.0.html
+++ b/examples/localization_v1.2.0.html
@@ -39,7 +39,7 @@
                         fillOpacity: 0.8
                     }).addTo(map);
 
-            L.browserPrint({
+            L.control.browserPrint({
                 printModesNames: { Custom:"Séléctionnez la zone" }
             }).addTo(map);
 

--- a/examples/manipulations_v1.2.0.html
+++ b/examples/manipulations_v1.2.0.html
@@ -40,7 +40,7 @@
                         fillOpacity: 0.8
                     }).addTo(map);                    
                     
-            L.browserPrint({
+            L.control.browserPrint({
                 printLayer:  L.tileLayer('//stamen-tiles-{s}.a.ssl.fastly.net/toner/{z}/{x}/{y}.png', {
                                 attribution: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a> &mdash; Map data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
                                 subdomains: 'abcd',

--- a/examples/print-with-legend_v1.2.0.html
+++ b/examples/print-with-legend_v1.2.0.html
@@ -154,7 +154,7 @@
 	// Here we are creating control to show it on the map;
 	L.legendControl({position: 'bottomright'}).addTo(map);
     
-    L.browserPrint().addTo(map);
+    L.control.browserPrint().addTo(map);
 	
 	map.on("browser-print-start", function(e){
 		/*on print start we already have a print map and we can create new control and add it to the print map to be able to print custom information */

--- a/examples/v0.7.7.html
+++ b/examples/v0.7.7.html
@@ -39,7 +39,7 @@
                         fillOpacity: 0.8
                     }).addTo(map);
 
-            L.browserPrint().addTo(map);
+            L.control.browserPrint().addTo(map);
 
     	</script>
     </body>

--- a/examples/v1.2.0.html
+++ b/examples/v1.2.0.html
@@ -43,7 +43,7 @@
                     
             L.layerGroup().addLayer(red).addLayer(green).addTo(map);
             
-            L.browserPrint().addTo(map);
+            L.control.browserPrint().addTo(map);
 
     	</script>
     </body>

--- a/src/leaflet.browser.print.js
+++ b/src/leaflet.browser.print.js
@@ -471,7 +471,7 @@ L.Control.BrowserPrint = L.Control.extend({
 	}
 });
 
-L.browserPrint = function(options) {
+L.control.browserPrint = function(options) {
 
 	if (options && options.printModes && (!options.printModes.filter || !options.printModes.length)) {
 		throw "Please specify valid print modes for Print action. Example: printModes: ['Portrait', 'Landscape', 'Auto', 'Custom']";


### PR DESCRIPTION
If a user want use leaflet.browser.print in a angular environement, he need find L.control.browserPrint().addTo(map);

Good practice is L.control.CUSTOM_CONTROL(

Tutorial [here](http://odoe.net/blog/custom-leaflet-control/):

```

L.Control.Sample = L.Control.extend({
  options: {
    // topright, topleft, bottomleft, bottomright
    position: 'topright'
  },
  initialize: function (options) {
    // constructor
  },
  onAdd: function (map) {
    // happens after added to map
  },
  onRemove: function (map) {
    // when removed
  }
});

L.control.sample = function(id, options) {
  return new L.Control.Sample(id, options);
}
```

Can you create a new version (use in production) please? Once the new version available on npm repository, I could make a demo application on my github that shows how to integrate your leaflet.browser.print in an Angular 5 application sample. Thank you in advance.