### PR TITLE
Wait for tiles to be ready

### DIFF
--- a/src/leaflet.browser.print.js
+++ b/src/leaflet.browser.print.js
@@ -261,7 +261,7 @@ L.Control.BrowserPrint = L.Control.extend({
 		overlay.map.invalidateSize({reset: true, animate: false, pan: false});
 
 		var interval = setInterval(function(){
-			if (!overlay.map.isLoading()) {
+			if (!overlay.map.isLoading() && !origins.printLayer.isLoading()) {
 				clearInterval(interval);
 				self._completePrinting(overlay.map, origins.printLayer, overlay.objects);
 			}


### PR DESCRIPTION
Hello, I'm working on a project using your plugin. I open this PR as, when you extend widely the print area, you need to wait for background tiles to be ready. This condition is also useful for regular prints on slow Internet connections.
Regards.