### PR TITLE
Fixing the custom print button action

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,8 +308,8 @@ Example:
 ```
 
 And add next css to hide onmap menu:
-``` CSS
-	.leaflet-control-browser-print {display: none;}
+```js
+	document.querySelector('.leaflet-control-browser-print').style.display = 'none';
 ```
 ### Important notes
 ````


### PR DESCRIPTION
Most of the time, in web development, we used to write our CSS code inside the head section and js code on the bottom of the HTML file.  When I tried to remove the default icon, it was not removed because my CSS is already loaded and the actual icon coming from the `leaflet.browser.print.min.js` file, which was linked at the bottom of the HTML file. So it is recommended to write the style through js below the initialization of the library, something like this, 

```js
L.control.browserPrint().addTo(map);
$(".print-map").on("click", function () {
  const modeToUse = L.control.browserPrint.mode.landscape();
  map.printControl.print(modeToUse);
});

$(".leaflet-control-browser-print").css({
  display: "none",
});
```