### PR TITLE
Issue #125:  Adding main to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "leaflet.browser.print",
   "version": "2.0.2",
+  "main": "dist/leaflet.browser.print",
   "keywords": [
     "leaflet.js",
     "browser",


### PR DESCRIPTION
The one line fix mentioned in https://github.com/Igor-Vladyka/leaflet.browser.print/issues/125