### PR TITLE
Clear isPrinting flag after unsuccessful custom print

### DIFF
--- a/src/leaflet.browser.print.js
+++ b/src/leaflet.browser.print.js
@@ -130,6 +130,7 @@ L.BrowserPrint = L.Class.extend({
 			delete this.options.custom;
 		} else {
 			this._clearPrint();
+            this._map.isPrinting = false;
 		}
 	},
 	_removeAutoPolygon: function(){


### PR DESCRIPTION
![already_printing](https://github.com/Igor-Vladyka/leaflet.browser.print/assets/19800037/6f974f23-03d6-464e-842b-b6e031017e58)

Happens if you create a custom area without moving the mouse -> No area is selected