### PR TITLE
Make the control usable with touch events

### DIFF
--- a/src/leaflet.browser.print.control.js
+++ b/src/leaflet.browser.print.control.js
@@ -27,8 +27,8 @@ L.Control.BrowserPrint = L.Control.extend({
 
 
 		if (this.options.printModes.length > 1) {
-			L.DomEvent.on(container, 'mouseover', this._displayPageSizeButtons, this);
-			L.DomEvent.on(container, 'mouseout', this._hidePageSizeButtons, this);
+            L.DomEvent.on(container, 'click', this._displayPageSizeButtons, this);
+            map.on('click', this._hidePageSizeButtons, this);
 		} else {
 			container.style.cursor = "pointer";
 		}
@@ -44,7 +44,7 @@ L.Control.BrowserPrint = L.Control.extend({
 		map.printControl = this; // Make control available from the map object itself;
 		return container;
 	},
-	
+
 	cancel: function () {
 		this.browserPrint.cancel();
 	},
@@ -105,6 +105,12 @@ L.Control.BrowserPrint = L.Control.extend({
 	},
 
     _displayPageSizeButtons: function() {
+	    if(this._controlIsOpen){
+	        // close control with click
+	        this._hidePageSizeButtons();
+	        return;
+        }
+	    this._controlIsOpen = true;
 		if (this.options.position.indexOf("left") > 0) {
 	        this.__link__.style.borderTopRightRadius = "0px";
 	    	this.__link__.style.borderBottomRightRadius = "0px";
@@ -119,6 +125,7 @@ L.Control.BrowserPrint = L.Control.extend({
     },
 
     _hidePageSizeButtons: function () {
+        this._controlIsOpen = false;
 		if (this.options.position.indexOf("left") > 0) {
 	    	this.__link__.style.borderTopRightRadius = "";
 	    	this.__link__.style.borderBottomRightRadius = "";


### PR DESCRIPTION
Old with mouse:
![old_control_mouse](https://github.com/Igor-Vladyka/leaflet.browser.print/assets/19800037/b64ab0e6-6af7-4eb1-865e-1405677fc25d)

Old with touch:
![old_control](https://github.com/Igor-Vladyka/leaflet.browser.print/assets/19800037/e84183a2-f844-47e9-ac8b-e5c581dc30fc)

New with mouse:
![new_control_mouse](https://github.com/Igor-Vladyka/leaflet.browser.print/assets/19800037/1904667f-30f9-4e80-947b-a04975d29877)

New with touch:
![new_controlgif](https://github.com/Igor-Vladyka/leaflet.browser.print/assets/19800037/40714c51-f100-4407-9626-ae779872f31c)

Now the control isn'T opening on mouseover anymore instead the user needs to click on the control
