### PR TITLE
Fix origin documentTitle error while cancel

### DIFF
--- a/src/leaflet.browser.print.js
+++ b/src/leaflet.browser.print.js
@@ -214,6 +214,7 @@ L.BrowserPrint = L.Class.extend({
 			printLayer: L.BrowserPrint.Utils.cloneLayer(this.options.printLayer),
 			panes: []
 		};
+		this._documentTitle = origins.documentTitle;
 
 		var mapPanes = this._map.getPanes();
 		for (var pane in mapPanes) {
@@ -339,7 +340,7 @@ L.BrowserPrint = L.Class.extend({
 
 		document.body.className = document.body.className.replace(" leaflet--printing", "");
 		if (this.options.documentTitle) {
-			document.title = origins.documentTitle;
+			document.title = this._documentTitle;
 		}
 
 		this._map.invalidateSize({reset: true, animate: false, pan: false});


### PR DESCRIPTION
![grafik](https://github.com/Igor-Vladyka/leaflet.browser.print/assets/19800037/bb03bfd5-03a3-4721-a119-c993832ef2a4)

If a documentTitle is set and then the print is canceled, it throws an error, because `origin` is not availbe on `_printCancel`