### PR TITLE
Removing high-dpi check because it is not necessary anymore (and wrong implemented)

### DIFF
--- a/src/leaflet.browser.print.helpers.js
+++ b/src/leaflet.browser.print.helpers.js
@@ -86,8 +86,8 @@ L.BrowserPrint.Helper = {
 		var height = Math.floor(size.Height - topbottom);
 		var width = Math.floor(size.Width - leftright);
 
-		size.Width = width * (window.devicePixelRatio || 1) + 'mm';
-		size.Height = height * (window.devicePixelRatio || 1) + 'mm';
+		size.Width = width + 'mm';
+		size.Height = height + 'mm';
 
 		return size;
 	}


### PR DESCRIPTION
With the commit https://github.com/Igor-Vladyka/leaflet.browser.print/commit/2e2239e73ed2f3eff633f7e3d721bd6d33ffd574 a fix for screens with 150% resolution (#81) was added: 

https://github.com/Igor-Vladyka/leaflet.browser.print/blob/2e2239e73ed2f3eff633f7e3d721bd6d33ffd574/src/leaflet.browser.print.sizes.js#L126-L131

With the V2 rewrite the logic was implemented wrong. Before the devicePixelRatio was added to the margin and subtracted from the size, now it is multipled with the size.
https://github.com/Igor-Vladyka/leaflet.browser.print/blob/2378e6e47664c7f578c786fab41c6d0bc1611c66/src/leaflet.browser.print.helpers.js#L83-L92

Which causes that for displays with 150% scale, the map is rendered on two pages:
![grafik](https://github.com/user-attachments/assets/4c617488-3219-4410-9b25-ec6d2afcfcdd)

Removing the devicePixelRatio fixes the issue:
![grafik](https://github.com/user-attachments/assets/eb9b8217-481f-4f59-b33b-cda4f9f5b696)

I checked out the old commit https://github.com/Igor-Vladyka/leaflet.browser.print/commit/2e2239e73ed2f3eff633f7e3d721bd6d33ffd574 to see for which reasons the devicePixelRatio was added but it looks like it was never necessary? Maybe the browsers have changed printing too
https://github.com/Igor-Vladyka/leaflet.browser.print/blob/2e2239e73ed2f3eff633f7e3d721bd6d33ffd574/src/leaflet.browser.print.sizes.js#L126-L131
Here are images of the commit with and without devicePixelRatio:

With devicePixelRatio: smaller margin and additional content is on the first page:
![grafik](https://github.com/user-attachments/assets/ae186c96-d080-4225-9d33-c840fd7b4f6b)

Without devicePixelRatio the margins are equal:
![grafik](https://github.com/user-attachments/assets/123f496a-c7d4-4cd4-ba2a-952268ca0481)

@Igor-Vladyka are you able to find out if the changes of https://github.com/Igor-Vladyka/leaflet.browser.print/commit/2e2239e73ed2f3eff633f7e3d721bd6d33ffd574 are still needed?
