### PR TITLE
New feature: exactArea

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ L.BrowserPrint.Mode.Landscape(pageSize,options);
 | scale         | Double       | 1             | Scale the map. Shows all bigger or smaller, with `1` the map looks normal |
 | header        | Object       |               | Adds a header section to the top of the page. For the available options look in the "Header / Footer Options" table below |
 | footer        | Object       |               | Adds a footer section to the bottom of the page. For the available options look in the "Header / Footer Options" table below |
+| exactArea     | Boolean      |               | Prints only the selected area without zooming on the map. |
 
 #### Header / Footer Options
 | Option        | Type         | Default      | Description   |

--- a/src/leaflet.browser.print.helpers.js
+++ b/src/leaflet.browser.print.helpers.js
@@ -4,6 +4,14 @@
 **/
 
 L.BrowserPrint.Helper = {
+	pxToMm: function (px) {
+		return (px / (96 / 2.54)) * 10;
+	},
+
+	mmToPx: function (mm) {
+		return (mm / 10) * (96 / 2.54);
+	},
+
 	getPageMargin: function (mode,type) {
 		var margin = mode.options.margin;
 		var size = this.getPaperSize(mode);
@@ -47,6 +55,12 @@ L.BrowserPrint.Helper = {
 		};
 	},
 	getPaperSize: function (mode) {
+		if(mode.Width){
+			return {
+				Width: mode.Width,
+				Height: mode.Height,
+			};
+		}
 		if (mode.options.pageSeries) {
 			var series = L.BrowserPrint.Size[mode.options.pageSeries];
 			var w = series.Width;
@@ -78,8 +92,18 @@ L.BrowserPrint.Helper = {
 	},
 	getSize: function (mode, orientaion = 'Portrait') {
 		var size = this.getPaperSize(mode);
-		var pageMargin = this.getPageMargin(mode, 0);
-
+		var pageMargin;
+		if(mode.Width){
+			pageMargin = {
+				top: 0,
+				right: 0,
+				bottom: 0,
+				left: 0
+			};
+		}
+		else{
+			pageMargin = this.getPageMargin(mode, 0);
+		}
 		var topbottom = orientaion === 'Portrait' ? parseFloat(pageMargin.top) + parseFloat(pageMargin.bottom) : parseFloat(pageMargin.left) + parseFloat(pageMargin.right);
 		var leftright = orientaion === 'Portrait' ? parseFloat(pageMargin.left) + parseFloat(pageMargin.right) : parseFloat(pageMargin.top) + parseFloat(pageMargin.bottom);
 

--- a/src/leaflet.browser.print.js
+++ b/src/leaflet.browser.print.js
@@ -270,15 +270,13 @@ L.BrowserPrint = L.Class.extend({
 
 		this._map.fire(L.BrowserPrint.Event.PrintStart, { printLayer: origins.printLayer, printMap: overlay.map, printObjects: overlay.objects });
 
-		if (options.invalidateBounds) {
+		if(options.exactArea){
+			overlay.map.setView(origins.bounds.getCenter(), this._map.getZoom(), { animate: false, pan: false });
+		} else if (options.invalidateBounds) {
 			overlay.map.fitBounds(origins.bounds, overlay.map.options);
 			overlay.map.invalidateSize({reset: true, animate: false, pan: false});
 		} else {
-			if(options.exactArea){
-				overlay.map.setView(origins.bounds.getCenter(), this._map.getZoom(), { animate: false, pan: false });
-			} else {
-				overlay.map.setView(this._map.getCenter(), this._map.getZoom(), { animate: false, pan: false });
-			}
+			overlay.map.setView(this._map.getCenter(), this._map.getZoom(), { animate: false, pan: false });
 		}
 
 		if(options.zoom){
@@ -406,8 +404,8 @@ L.BrowserPrint = L.Class.extend({
 		var printStyleSheet = document.createElement('style');
 		printStyleSheet.className = "leaflet-browser-print-css";
 		printStyleSheet.setAttribute('type', 'text/css');
-		printStyleSheet.innerText = " .leaflet-print-overlay .grid-print-container { transform: scale(var(--exact-print-zoom)); transform-origin: top left; }";
-		printStyleSheet.innerText += " .leaflet-print-overlay .leaflet-control-attribution { transform: scale(calc(1/var(--exact-print-zoom))); transform-origin: bottom right; }";
+		printStyleSheet.innerText = " .leaflet-print-overlay .grid-print-container { zoom: var(--exact-print-zoom) }";
+		printStyleSheet.innerText += " .leaflet-print-overlay .leaflet-control-container { zoom: calc(1 / var(--exact-print-zoom)) }";
 
 		printStyleSheet.innerHTML += ' @media print { .leaflet-popup-content-wrapper, .leaflet-popup-tip { box-shadow: none; }';
 		printStyleSheet.innerHTML += ' .leaflet-browser-print--manualMode-button { display: none; }';


### PR DESCRIPTION
Allows printing the selected area using the same zoom level as in custom mode, without any changes to zoom or position

```
L.BrowserPrint.Mode.Custom("B5",{title:"Select area", exactArea: true})
```